### PR TITLE
Update responsive changes for mdc table

### DIFF
--- a/src/app/features/orders/orders-table/orders-table.component.scss
+++ b/src/app/features/orders/orders-table/orders-table.component.scss
@@ -6,6 +6,6 @@
     width: 50%;
 }
 
-.mat-column-actions {
+.mat-column-actions, .mat-column-subtotal, .mat-column-status {
     width: 10%
 }

--- a/src/app/features/orders/orders-table/orders-table.component.scss
+++ b/src/app/features/orders/orders-table/orders-table.component.scss
@@ -4,6 +4,7 @@
 
 .mat-column-items {
     width: 50%;
+    min-width: 250px;
 }
 
 .mat-column-actions, .mat-column-subtotal, .mat-column-status {

--- a/src/app/shared/ui/confirmation-dialog/confirmation-dialog.component.html
+++ b/src/app/shared/ui/confirmation-dialog/confirmation-dialog.component.html
@@ -1,7 +1,7 @@
 <h2 mat-dialog-title>Confirmation</h2>
 
 <mat-dialog-content>
-    Are you sure you want to process?
+    Are you sure you want to proceed?
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">

--- a/src/app/shared/ui/layout/header/header.component.html
+++ b/src/app/shared/ui/layout/header/header.component.html
@@ -9,7 +9,7 @@
      } @else {
      <div class="m-2">
           <button mat-flat-button color="primary" class="mr-2" (click)="openLoginDialog()">Login</button>
-          <button mat-raised-button color="primary" (click)="openRegisterDialog()">Register</button>
+          <button mat-stroked-button color="primary" (click)="openRegisterDialog()">Register</button>
      </div>
      }
 

--- a/src/app/shared/ui/submit-button/submit-button.component.html
+++ b/src/app/shared/ui/submit-button/submit-button.component.html
@@ -1,6 +1,6 @@
 <button mat-flat-button [disabled]="disabled() || isSubmitting()" (click)="action.emit()">
     @if (isSubmitting()) {
-      <mat-icon><mat-spinner diameter="20"></mat-spinner></mat-icon>
+      <mat-icon><mat-spinner diameter="16"></mat-spinner></mat-icon>
     }
     <ng-content></ng-content>
 </button>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 @import './styles/utils.scss';
+@import './styles/elements/table';
+@import './styles/mixins/responsive-utils.scss';
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/src/styles/elements/table.scss
+++ b/src/styles/elements/table.scss
@@ -1,0 +1,4 @@
+.mdc-data-table__table {
+    min-width: 500px !important;
+    width: 100%;
+}

--- a/src/styles/elements/table.scss
+++ b/src/styles/elements/table.scss
@@ -1,4 +1,0 @@
-.mdc-data-table__table {
-    min-width: 500px !important;
-    width: 100%;
-}

--- a/src/styles/mixins/responsive-utils.scss
+++ b/src/styles/mixins/responsive-utils.scss
@@ -1,0 +1,35 @@
+@mixin layout-xs() {
+    @media screen and (max-width: 575px) {
+        @content;
+    }
+}
+
+@mixin layout-sm() {
+    @media screen and (min-width: 576px) {
+        @content;
+    }
+}
+
+@mixin layout-md() {
+    @media screen and (min-width: 768px) {
+        @content;
+    }
+}
+
+@mixin layout-lg() {
+    @media screen and (min-width: 992px) {
+        @content;
+    }
+}
+
+@mixin layout-xl() {
+    @media screen and (min-width: 1200px) {
+        @content;
+    }
+}
+
+@mixin layout-xxl() {
+    @media screen and (min-width: 1400px) {
+        @content;
+    }
+}


### PR DESCRIPTION
Update `min-width` for table so item column does not break word
Minor UI changes:
Login spinner size is more suitable

![image](https://github.com/anhptk/group-order/assets/27537475/44edde2b-88ab-4702-b1c5-aac1e451cba5)
![image](https://github.com/anhptk/group-order/assets/27537475/231b6336-a6a0-49a3-bbe8-9c5531ed0002)
